### PR TITLE
Switch to a version number permitted by Dist::Zilla::Plugin::BumpVersionAfterRelease

### DIFF
--- a/lib/WWW/PushBullet.pm
+++ b/lib/WWW/PushBullet.pm
@@ -40,7 +40,7 @@ use JSON;
 use LWP::UserAgent;
 use MIME::Types;
 
-our $VERSION = '1.4.0';
+our $VERSION = '1.5';
 
 my %PUSHBULLET = (
     REALM     => 'Pushbullet',


### PR DESCRIPTION
When I try to `dzil build` I get this:

```
[DZ] beginning to build WWW-PushBullet
[DZ] guessing dist's main_module is lib/WWW/PushBullet.pm
[RewriteVersion] 1.4.0 is not an allowed version string (maybe you need 'allow_decimal_underscore')
[RewriteVersion] 1.4.0 is not an allowed version string (maybe you need 'allow_decimal_underscore') at inline delegation in Dist::Zilla::Plugin::RewriteVersion for logger->log_fatal (attribute declared in /usr/local/share/perl/5.18.2/Dist/Zilla/Role/Plugin.pm at line 59) line 18.
```

According to http://search.cpan.org/~dagolden/Dist-Zilla-Plugin-BumpVersionAfterRelease-0.015/lib/Dist/Zilla/Plugin/BumpVersionAfterRelease.pm
which is in use in because of `[RewriteVersion]` in dist.ini, version
numbers should not be in tuple format.

This change allows dzil build to succeed. I'm assuming that this would
be the next release number and that it can stay like this until
released.